### PR TITLE
fix #14 use configParams for username and password

### DIFF
--- a/utils/src/main/java/org/ballerinalang/java/jms/JmsConnectionUtils.java
+++ b/utils/src/main/java/org/ballerinalang/java/jms/JmsConnectionUtils.java
@@ -133,11 +133,11 @@ public class JmsConnectionUtils {
             InitialContext initialContext = new InitialContext(properties);
             ConnectionFactory connectionFactory =
                     (ConnectionFactory) initialContext.lookup(connectionFactoryName.getValue());
-            if (optionalConfigs.containsKey(Constants.ALIAS_USERNAME)) {
-                username = optionalConfigs.get(Constants.ALIAS_USERNAME).getValue();
+            if (configParams.containsKey(Constants.ALIAS_USERNAME)) {
+                username = configParams.get(Constants.ALIAS_USERNAME).getValue();
             }
-            if (optionalConfigs.containsKey(Constants.ALIAS_PASSWORD)) {
-                password = optionalConfigs.get(Constants.ALIAS_PASSWORD).getValue();
+            if (configParams.containsKey(Constants.ALIAS_PASSWORD)) {
+                password = configParams.get(Constants.ALIAS_PASSWORD).getValue();
             }
             if (JmsUtils.notNullOrEmptyAfterTrim(username) && password != null) {
                 return connectionFactory.createConnection(username, password);


### PR DESCRIPTION
## Purpose
#14 username and password were used from the JNDI properties instead of the config fields

## Goals
use the intended fields for username and password

