### PR TITLE
new functions to close connection #4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget https://product-dist.ballerina.io/downloads/1.2.0/ballerina-linux-installer-x64-1.2.0.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-1.2.0.deb
+  - wget https://dist.ballerina.io/downloads/1.2.11/ballerina-linux-installer-x64-1.2.11.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-1.2.11.deb
   - sudo apt-get install -f
   - export JAVA_OPTS="-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
   - mvn clean install -DskipTests=true

--- a/java.jms/src/java.jms/connection.bal
+++ b/java.jms/src/java.jms/connection.bal
@@ -52,6 +52,10 @@ public type Connection client object {
         }
     }
 
+    public remote function close() returns error? {
+        return closeJmsConnection(self.jmsConnection);
+    }
+
     # Create a Session object, specifying transacted and acknowledgeMode
     #
     # + sessionConfig - SessionConfiguration record consist with JMS session config
@@ -118,5 +122,10 @@ function startJmsConnection(handle jmsConnection) returns error? = @java:Method 
 
 function stopJmsConnection(handle jmsConnection) returns error? = @java:Method {
     name: "stop",
+    class: "javax.jms.Connection"
+} external;
+
+function closeJmsConnection(handle jmsConnection) returns error? = @java:Method {
+    name: "close",
     class: "javax.jms.Connection"
 } external;


### PR DESCRIPTION
## Purpose
Resolves #4 --> Currently there is no way to actively close a JMS connections

## Goals
Introducing ability to close a JMS connection

## Samples
```ballerina
import ballerina/java.jms;
import ballerina/log;

public function main() returns error? {
    jms:Connection connection = check jms:createConnection({
      initialContextFactory: "com.tibco.tibjms.naming.TibjmsInitialContextFactory",
      providerUrl: "tcp://localhost:10101",
      connectionFactoryName:"QueueConnectionFactory",
      username: "user",
      password: "pass",
      //workaround to fix authentication issue
      properties:{
          "java.naming.security.principal": "user",
          "java.naming.security.credentials": "pass",
          "username": "user",
          "password": "pass"
        }
    });
    log:printInfo("Connection Created");
    log:printInfo(connection.toString());
    _= check connection->close(); // this is not possible without this change
    jms:Session?|error session = connection->createSession({acknowledgementMode: "AUTO_ACKNOWLEDGE"});
    if (session is jms:Session) {
      log:printInfo("Connection still open - this is not what we want.");
  } else {
      log:printInfo("Connection successfully closed");
      log:printInfo(session.toString());
  }
}
```

## Note
I'm new to contributing to open source projects. Please let me know if you any hints about how to do this more effectively in this  project.