### PR TITLE
Ballerina 1.2.x session close

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget https://product-dist.ballerina.io/downloads/1.2.0/ballerina-linux-installer-x64-1.2.0.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-1.2.0.deb
+  - wget https://product-dist.ballerina.io/downloads/1.2.11/ballerina-linux-installer-x64-1.2.11.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-1.2.11.deb
   - sudo apt-get install -f
   - export JAVA_OPTS="-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
   - mvn clean install -DskipTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 script:
-  - wget https://product-dist.ballerina.io/downloads/1.2.11/ballerina-linux-installer-x64-1.2.11.deb
+  - wget https://dist.ballerina.io/downloads/1.2.11/ballerina-linux-installer-x64-1.2.11.deb
   - sudo dpkg -i ballerina-linux-installer-x64-1.2.11.deb
   - sudo apt-get install -f
   - export JAVA_OPTS="-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"

--- a/java.jms/Ballerina.lock
+++ b/java.jms/Ballerina.lock
@@ -1,4 +1,4 @@
 org_name = "ballerina"
 version = "0.8.1"
 lockfile_version = "1.0.0"
-ballerina_version = "1.2.4"
+ballerina_version = "1.2.11"

--- a/java.jms/src/java.jms/session.bal
+++ b/java.jms/src/java.jms/session.bal
@@ -38,6 +38,11 @@ public type Session client object {
         registerAndIncrementCounter(new observe:Counter(TOTAL_JMS_SESSIONS));
     }
 
+    public remote function close() returns error? {
+        //TODO: unregister and decrementCounter
+        return closeJmsSession(self.jmsSession);
+    }
+
     # Unsubscribe a durable subscription that has been created by a client.
     # It is erroneous for a client to delete a durable subscription while there is an active (not closed) consumer
     # for the subscription, or while a consumed message being part of a pending transaction or has not been
@@ -349,6 +354,11 @@ function createJmsConsumer(handle jmsSession, handle jmsDestination,
 
 function createJmsSession(handle connection, handle acknowledgmentMode) returns handle | error = @java:Method {
     class: "org.ballerinalang.java.jms.JmsSessionUtils"
+} external;
+
+function closeJmsSession(handle session) returns error? = @java:Method {
+    name: "close",
+    class: "javax.jms.Session"
 } external;
 
 function unsubscribeJmsSubscription(handle session, handle subscriptionId) returns error? = @java:Method {


### PR DESCRIPTION
## Purpose
Currentyl JMS sessions can not be actively closed. 

## Goals
Enable to close JMS sessions

## Sample
```ballerina
import ballerina/java.jms;
import ballerina/log;


public function main() returns error? {
  jms:Connection connection = check jms:createConnection({
    initialContextFactory: "com.tibco.tibjms.naming.TibjmsInitialContextFactory",
    providerUrl: "tcp://localhost:10101",
    connectionFactoryName:"QueueConnectionFactory",
    username: "user",
    password: "pass",
    //workaround to fix authentication issue
    properties:{
        "java.naming.security.principal": "user",
        "java.naming.security.credentials": "pass",
        "username": "user",
        "password": "pass"
      }
  });

  jms:Session session = check connection->createSession({acknowledgementMode: "AUTO_ACKNOWLEDGE"});
  log:printInfo("Session Created");
  _ = check session->close(); //using new function
  jms:Destination|error queue = session->createQueue("MyQueue");
  if (queue is jms:Destination) {
    log:printInfo("Session should be closed but is not - this is not what we want.");
  } else {
      log:printInfo("Session successfully closed");
      log:printInfo(queue.toString());  
  }
}
```